### PR TITLE
Added check for empty lines in Bots CSV file

### DIFF
--- a/GoogleAnalyticsServerSide.php
+++ b/GoogleAnalyticsServerSide.php
@@ -963,9 +963,11 @@ class GoogleAnalyticsServerSide {
 		$botList = explode("\n", $fileContexts);
 		$distinctBots = array();
 		foreach ($botList as $line) {
-			$csvLine = str_getcsv($line);
-			if (!isset($distinctBots[$csvLine[0]])) {
-				$distinctBots[$csvLine[0]] = (isset($csvLine[6])) ? $csvLine[6] : $csvLine[1];
+			if ( !empty($line)) {
+				$csvLine = str_getcsv($line);
+				if (!isset($distinctBots[$csvLine[0]])) {
+					$distinctBots[$csvLine[0]] = (isset($csvLine[6])) ? $csvLine[6] : $csvLine[1];
+				}
 			}
 		}
 		return $distinctBots;


### PR DESCRIPTION
For some reason my bots.csv is blank sometimes, this check stops the PHP Notice from happening in the error log. I'd imagine it'd also help if there are any blank lines in a populated file?
