### PR TITLE
remove deprecated filter_var options, theses options are already defa…

### DIFF
--- a/Gass/Validate/Url.php
+++ b/Gass/Validate/Url.php
@@ -47,7 +47,7 @@ class Url extends Base
             $this->addMessage('The provided URL must be a string.');
             return false;
         }
-        $validated = filter_var($value, FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED | FILTER_FLAG_HOST_REQUIRED);
+        $validated = filter_var($value, FILTER_VALIDATE_URL);
         if (false === $validated) {
             $this->addMessage('"%value%" is an invalid URL');
             return false;


### PR DESCRIPTION
…ulted to on for FILTER_VALIDATE_URL and are ignored since as long ago as PHP 5.2.1.  See https://stackoverflow.com/questions/45240033/what-is-use-of-filter-flag-scheme-required-and-filter-flag-host-required-flags-f